### PR TITLE
init extension when browser is updated

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
 	"manifest_version": 3,
 	"name": "GMT/UTC Clock",
 	"description": "UTC Clock extension for Google Chrome.",
-	"version": "5.0.0",
+	"version": "5.1.0",
 	"author": "Casey Hunt",
 	"background": {
 		"service_worker": "sw.js"

--- a/sw.js
+++ b/sw.js
@@ -6,16 +6,33 @@ const timeFormatOpts = {
   timeZone: 'UTC',
 }
 
-function updateClock() {
+/** @type {ReturnType<typeof setTimeout>} */
+let timeout
+
+chrome.runtime.onStartup.addListener(() => {
+  if (!timeout) {
+    init()
+  }
+})
+
+const badgeColor = () => {
+  chrome.action.setBadgeBackgroundColor({ color: [0, 215, 0, 255] })
+}
+
+const updateClock = () => {
   const date = new Date()
 
   chrome.action.setBadgeText({
     text: date.toLocaleTimeString(undefined, timeFormatOpts),
   })
 
-  setTimeout(updateClock, 5000)
+  timeout = setTimeout(updateClock, 5000)
 }
 
-//Run Clock function & set badge
-chrome.action.setBadgeBackgroundColor({ color: '#00d700' })
-updateClock()
+/** Start clock timer & set badge color */
+const init = () => {
+  updateClock()
+  badgeColor()
+}
+
+init()

--- a/sw.js
+++ b/sw.js
@@ -15,10 +15,6 @@ chrome.runtime.onStartup.addListener(() => {
   }
 })
 
-const badgeColor = () => {
-  chrome.action.setBadgeBackgroundColor({ color: [0, 215, 0, 255] })
-}
-
 const updateClock = () => {
   const date = new Date()
 
@@ -32,7 +28,7 @@ const updateClock = () => {
 /** Start clock timer & set badge color */
 const init = () => {
   updateClock()
-  badgeColor()
+  chrome.action.setBadgeBackgroundColor({ color: [0, 215, 0, 255] })
 }
 
 init()


### PR DESCRIPTION
Extension does not seem to automatically run when browser is closed and reopened.  Seems related to the (now required) service worker being deemed inactive for some reason.  Attempt to fix this by hooking into the `onStartup` event.

Possibly related to: https://stackoverflow.com/questions/71724980/chrome-extension-always-show-service-worker-inactive-after-browser-restart-if