### PR TITLE
remove if check before init-ing timer on startup

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -6,15 +6,6 @@ const timeFormatOpts = {
   timeZone: 'UTC',
 }
 
-/** @type {ReturnType<typeof setTimeout>} */
-let timeout
-
-chrome.runtime.onStartup.addListener(() => {
-  if (!timeout) {
-    init()
-  }
-})
-
 const updateClock = () => {
   const date = new Date()
 
@@ -22,7 +13,7 @@ const updateClock = () => {
     text: date.toLocaleTimeString(undefined, timeFormatOpts),
   })
 
-  timeout = setTimeout(updateClock, 5000)
+  setTimeout(updateClock, 5000)
 }
 
 /** Start clock timer & set badge color */
@@ -31,4 +22,5 @@ const init = () => {
   chrome.action.setBadgeBackgroundColor({ color: [0, 215, 0, 255] })
 }
 
+chrome.runtime.onStartup.addListener(init)
 init()


### PR DESCRIPTION
Previous change did not seem sufficient to resolve issue where extension did not initialize when browser was reopened after being closed for a significant period (overnight).