### PR TITLE
convert from setinterval to alarms api

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
-    "checkJs": true
+    "checkJs": true,
+    "target": "es2020",
   },
   "exclude": [
     "node_modules"

--- a/manifest.json
+++ b/manifest.json
@@ -7,6 +7,9 @@
 	"background": {
 		"service_worker": "sw.js"
 	},
+	"permissions": [
+		"alarms"
+	],
 	"action": {
 		"default_title": "UTC Clock",
 		"default_icon": "images/icon2.png",


### PR DESCRIPTION
Actually move off of `setInterval` to Chrome's preferred Alarms API.  As the permissions of the extension have changed (from nothing to something), this will likely prompt users to re-enable the extension or at least notify them that the Permissions have changed, so we should address this with a changelog note.